### PR TITLE
feat: Implement backend proxy to fix CORS error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+# netlify.toml
+
+[build]
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200

--- a/netlify/functions/generate.js
+++ b/netlify/functions/generate.js
@@ -1,0 +1,56 @@
+// /netlify/functions/generate.js
+
+exports.handler = async function(event) {
+  // 1. We only care about POST requests.
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  // 2. Get the API key from environment variables.
+  const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
+  if (!GOOGLE_API_KEY) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'API key is not set.' }) };
+  }
+
+  // 3. Get the prompt from the request body.
+  const body = JSON.parse(event.body);
+  const prompt = body.prompt;
+  if (!prompt) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Prompt is required.' }) };
+  }
+
+  // 4. Call the Google Gemini API.
+  const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GOOGLE_API_KEY}`;
+
+  try {
+    const response = await fetch(API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
+    });
+
+    if (!response.ok) {
+      // Forward the error from Google's API
+      const errorData = await response.json();
+      return {
+        statusCode: response.status,
+        body: JSON.stringify(errorData)
+      };
+    }
+
+    const data = await response.json();
+
+    // 5. Return the successful response to the frontend.
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    };
+
+  } catch (error) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to fetch from Google API.' })
+    };
+  }
+};

--- a/script.js
+++ b/script.js
@@ -1,9 +1,7 @@
 // --- НАЧАЛО КОДА ДЛЯ ПОЛНОЙ ЗАМЕНЫ В SCRIPT.JS ---
 document.addEventListener('DOMContentLoaded', () => {
     // --- Configuration ---
-    // ВАЖНО: Вставьте ваш настоящий API-ключ. Без него генерация не будет работать.
-    const API_KEY = 'AIzaSyCisFe9LE9ykOlc7JOn7NEJQDJ3LaMMFqI'; 
-    const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${API_KEY}`;
+    const API_URL = '/api/generate'; // The new proxy endpoint
 
     // --- State Management ---
     let suggestions = [];
@@ -247,15 +245,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const response = await fetch(API_URL, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
+            // The serverless function expects a JSON body with a `prompt` key.
+            body: JSON.stringify({ prompt: prompt })
         });
         if (!response.ok) {
             const errorData = await response.json();
-            throw new Error(errorData.error ? errorData.error.message : 'Unknown API error');
+            // The user will now see the more specific error message from the backend.
+            const errorMessage = errorData.error ? errorData.error.message : 'Unknown API error';
+            throw new Error(errorMessage);
         }
         const data = await response.json();
         if (!data.candidates || !data.candidates[0].content) {
-            throw new Error('Invalid API response structure');
+            throw new Error('Invalid API response structure from Google');
         }
         return data.candidates[0].content.parts[0].text;
     }


### PR DESCRIPTION
This commit introduces a backend proxy using a Netlify serverless function to resolve the CORS issue when calling the Google Gemini API.

The frontend (`script.js`) no longer calls the Google API directly. Instead, it sends requests to a new endpoint (`/api/generate`), which is handled by the serverless function.

The API key has been removed from the client-side code for security and is now handled on the server-side via environment variables.

A `netlify.toml` file is added to configure the build and redirect rules for the serverless function.