### PR TITLE
feat: Overhaul admin and user flows for improved UX

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -30,20 +30,37 @@
 
     <div id="admin-panel" style="display: none;">
         <h2>Панель администратора</h2>
-        <div class="admin-forms-container">
-            <div id="create-department-form">
-                <h3>Создать департамент</h3>
-                <input type="text" id="new-department-name" placeholder="Название департамента">
-                <input type="password" id="new-department-password" placeholder="Пароль">
-                <button id="create-department-btn">Создать</button>
-            </div>
-            <div id="create-chat-form">
-                <h3>Создать новый чат</h3>
-            <input type="text" id="new-chat-name" placeholder="Название чата">
-            <input type="password" id="new-chat-password" placeholder="Пароль чата">
-            <button id="create-chat-btn">Создать</button>
+
+        <div id="create-department-form">
+            <h3>Создать новый департамент</h3>
+            <input type="text" id="new-department-name" placeholder="Название департамента">
+            <input type="password" id="new-department-password" placeholder="Пароль">
+            <button id="create-department-btn">Создать</button>
         </div>
-        <div class="admin-tabs">
+
+        <hr>
+
+        <h3>Управление чатами</h3>
+        <div class="admin-main-view">
+            <div id="department-list-container">
+                <h4>Департаменты</h4>
+                <div id="department-list"></div>
+            </div>
+            <div id="chat-list-container">
+                <h4 id="chat-list-header">Чаты</h4>
+                <div id="chat-list"></div>
+                <div id="create-chat-form" style="display: none;">
+                    <h5>Создать новый чат для <span id="selected-department-name"></span></h5>
+                    <input type="text" id="new-chat-name" placeholder="Название чата">
+                    <input type="password" id="new-chat-password" placeholder="Пароль чата">
+                    <button id="create-chat-btn">Создать</button>
+                </div>
+            </div>
+        </div>
+
+        <hr>
+        <h3>Чаты на проверке</h3>
+         <div class="admin-tabs">
             <button class="tab-link active" onclick="openTab(event, 'in-review')">В работе</button>
             <button class="tab-link" onclick="openTab(event, 'completed')">Завершенные</button>
         </div>

--- a/backend/public/style.css
+++ b/backend/public/style.css
@@ -572,23 +572,59 @@ button.button-secondary:hover {
     background-color: #FAFAC8;
 }
 
-.admin-forms-container {
-    display: flex;
-    gap: 40px;
-    margin-bottom: 30px;
+.admin-main-view {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 30px;
 }
 
-#create-department-form, #create-chat-form {
-    flex: 1;
+#department-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.department-card {
+    padding: 15px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+}
+
+.department-card:hover {
+    background-color: #f8f9fa;
+}
+
+.department-card.selected {
+    background-color: var(--primary-color);
+    color: var(--white-color);
+    border-color: var(--primary-hover-color);
+}
+
+#chat-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.chat-item {
+    padding: 10px;
+    background-color: #f8f9fa;
+    border-radius: var(--border-radius);
+}
+
+#create-department-form {
+    margin-bottom: 20px;
     padding: 20px;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
-    margin-bottom: 20px;
 }
-#create-chat-form h3 {
+#create-department-form h3 {
     margin-top: 0;
 }
-#create-chat-form input {
+#create-department-form input {
     width: 100%;
     padding: 10px;
     margin-bottom: 10px;

--- a/backend/server.js
+++ b/backend/server.js
@@ -75,6 +75,18 @@ app.post('/api/departments', async (req, res) => {
     res.status(201).json(data);
 });
 
+// Admin: Get all departments
+app.get('/api/departments', async (req, res) => {
+    const { data, error } = await supabase
+        .from('departments')
+        .select('id, name');
+
+    if (error) {
+        return res.status(500).json({ error: error.message });
+    }
+    res.json(data);
+});
+
 // Admin: Get completed chats
 app.get('/api/admin/chats/completed', async (req, res) => {
     const { data, error } = await supabase


### PR DESCRIPTION
This commit introduces a major refactoring of the admin and user workflows to create a more intuitive and functional experience, based on detailed user feedback. It establishes a clear separation between admin and user roles and significantly improves the UI for managing departments and chats.

Key changes include:
- **Admin Dashboard:**
  - Logging in as `admin` now leads to a dedicated admin panel, bypassing the user-facing chat selection.
  - The panel displays a list of all departments, allowing the admin to select one to manage.
  - After selecting a department, the admin can view all its chats and create new ones specifically for that department, with immediate visual feedback.

- **UI/UX Improvements:**
  - The user-facing chat selection screen has been redesigned from a dropdown to a more visual card-based layout.
  - An empty state message is now displayed if a user logs into a department with no chats.

- **Backend Refinements:**
  - The logic for department creation has been moved from an automatic "create-on-login" flow to a manual process available only to administrators.
  - Added a new `GET /api/departments` endpoint to support the new admin dashboard.

This resolves critical usability issues, including admins being unable to see the chats they created and users being presented with a confusing empty screen.