### PR TITLE
fix(admin): Fix admin chat view not opening

### DIFF
--- a/backend/public/script.js
+++ b/backend/public/script.js
@@ -606,7 +606,19 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.target.tagName === 'A') {
             e.preventDefault();
             chatId = e.target.dataset.chatId;
+            const chatName = e.target.textContent;
+
+            // Hide admin panel and show the main chat container
+            adminPanel.style.display = 'none';
+            mainContainer.style.display = 'block';
+
+            // Set chat name and load its data
+            chatNameHeader.textContent = `Чат: ${chatName}`;
             loadChatData();
+
+            // Ensure admin-specific buttons are visible in the chat view
+            completeBtn.style.display = 'inline-block';
+            archiveBtn.style.display = 'inline-block';
         }
     }
 


### PR DESCRIPTION
The admin chat view was not opening when a chat was selected from the admin panel. The javascript was fetching the data but not updating the UI to show the chat container.

This commit modifies the `handleAdminChatSelection` function in `script.js` to correctly hide the admin panel and display the main chat container when a chat is selected.