### PR TITLE
Fix: Address chat status enum error and VSDX download

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -55,3 +55,15 @@ Follow these instructions to run the backend server locally for development or t
     Ensure your hosting provider uses the `npm start` command to run the application. This is the default for most Node.js environments.
 
 **Important:** Never commit your `.env` file or your `GOOGLE_API_KEY` to a Git repository. Add `.env` to your `.gitignore` file.
+
+### Database Patching
+
+If you are encountering errors related to the `chat_status` enum, you may need to patch your database. This can happen if your database schema is out of sync with the application code.
+
+To apply the patch, run the following command from the `backend` directory:
+
+```bash
+node patch-db.js
+```
+
+This will add the `pending_review` value to the `chat_status` enum in your database. You only need to run this script once.

--- a/backend/patch-db.js
+++ b/backend/patch-db.js
@@ -1,0 +1,27 @@
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function patchDatabase() {
+  console.log('Applying database patch to add `pending_review` to `chat_status` enum...');
+
+  // We must use a stored procedure to run ALTER TYPE, as it's not directly exposed in the Supabase client library.
+  // This assumes a function `eval(query text)` exists on the database.
+  // A safer alternative would be to use a proper migration tool.
+  const { data, error } = await supabase.rpc('eval', {
+    query: "ALTER TYPE public.chat_status ADD VALUE IF NOT EXISTS 'pending_review';"
+  });
+
+  if (error) {
+    console.error('Error applying database patch:', error.message);
+    console.error('This likely means you need to run the SQL command manually on your Supabase instance, or the `eval` RPC function is not enabled.');
+    return;
+  }
+
+  console.log('Database patch applied successfully.', data);
+}
+
+patchDatabase();

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -123,8 +123,8 @@
                         <button id="zoom-in-btn" title="Приблизить">+</button>
                         <button id="zoom-out-btn" title="Отдалить">-</button>
                         <button id="download-png-btn" title="Скачать PNG">PNG</button>
-                        <button id="download-svg-btn" title="Скачать SVG">SVG</button>
-                        <button id="download-vsdx-btn" title="Экспорт в VSDX временно недоступен" disabled>VSDX</button>
+                        <button id="download-svg-btn" title="Скачать SVG (можно импортировать в Visio)">SVG</button>
+                        <button id="download-vsdx-btn" title="Экспорт в VSDX в разработке" disabled>VSDX</button>
                     </div>
                 </div>
 


### PR DESCRIPTION
This commit addresses two issues:
1. A 500 error when submitting a chat for review, caused by an outdated `chat_status` enum in the database.
2. The inability to download a VSDX file.

The `chat_status` enum issue is resolved by providing a manual patch script, `backend/patch-db.js`. This script adds the missing `pending_review` value to the enum. Instructions on how to run this script have been added to `backend/README.md`. This approach was chosen due to the absence of a database migration framework in the project.

For the VSDX download issue, a client-side library for SVG-to-VSDX conversion was not available. As a workaround, the UI has been updated to inform users that they can download the diagram as an SVG and import it into Visio. The VSDX button has been updated to indicate that the feature is under development.