### PR TITLE
feat: Add 'In Progress' tab and fix VSDX download

### DIFF
--- a/backend/public/script.js
+++ b/backend/public/script.js
@@ -763,6 +763,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 </a>
             </li>
         `).join('');
+
+        const pendingResponse = await fetch('/api/admin/chats/pending');
+        const pendingChats = await pendingResponse.json();
+        pendingList.innerHTML = pendingChats.map(chat => `
+            <li>
+                <a href="#" data-chat-id="${chat.chat_id}">
+                    <span>${chat.chats.name}</span>
+                    <span class="chat-status-admin">${getStatusIndicator(chat.status)}</span>
+                </a>
+            </li>
+        `).join('');
     }
 
     async function handleDepartmentSelection(e) {


### PR DESCRIPTION
This commit introduces a new 'В работе' (In Progress) tab to the admin panel. This tab displays chats that are currently being worked on by departments (i.e., those with 'draft' or 'needs_revision' statuses), fulfilling a key user request.

The following changes were made:
- A new API endpoint `/api/admin/chats/pending` was created in `server.js` to serve the data for the new tab.
- The admin panel in `index.html` was updated to include the new tab structure.
- The `script.js` file was modified to fetch and render the chats for the "In Progress" tab.
- The VSDX download button is now disabled and provides an alert explaining that SVG is the recommended format for Visio import.
- Admin permissions have been expanded to allow interaction with chats regardless of their status.