### PR TITLE
fix: Resolve 500 error and improve admin panel robustness

### DIFF
--- a/backend/public/script.js
+++ b/backend/public/script.js
@@ -767,19 +767,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Load and render all chat lists
         try {
-            const [inReviewResponse, completedResponse, pendingResponse] = await Promise.all([
+            const responses = await Promise.all([
                 fetch('/api/admin/chats/in_review'),
                 fetch('/api/admin/chats/completed'),
                 fetch('/api/admin/chats/pending')
             ]);
 
-            const inReviewChats = await inReviewResponse.json();
+            for (const res of responses) {
+                if (!res.ok) {
+                    const errorBody = await res.text();
+                    throw new Error(`Failed to fetch ${res.url}: ${res.status} ${res.statusText}. Body: ${errorBody}`);
+                }
+            }
+
+            const [inReviewChats, completedChats, pendingChats] = await Promise.all(
+                responses.map(res => res.json())
+            );
+
             renderChatList(inReviewList, inReviewChats, 'In Review');
-
-            const completedChats = await completedResponse.json();
             renderChatList(completedList, completedChats, 'Completed');
-
-            const pendingChats = await pendingResponse.json();
             renderChatList(pendingList, pendingChats, 'Pending');
 
         } catch (error) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -48,7 +48,7 @@ app.post('/api/auth/department', async (req, res) => {
 app.get('/api/admin/chats/in_review', async (req, res) => {
     const { data, error } = await supabase
         .from('chat_statuses')
-        .select('*, chats(*)')
+        .select('chat_id, status, chats(name)')
         .eq('status', 'pending_review');
 
     if (error) {
@@ -61,7 +61,7 @@ app.get('/api/admin/chats/in_review', async (req, res) => {
 app.get('/api/admin/chats/pending', async (req, res) => {
     const { data, error } = await supabase
         .from('chat_statuses')
-        .select('*, chats(*)')
+        .select('chat_id, status, chats(name)')
         .in('status', ['draft', 'needs_revision']);
 
     if (error) {
@@ -119,7 +119,7 @@ app.get('/api/departments', async (req, res) => {
 app.get('/api/admin/chats/completed', async (req, res) => {
     const { data, error } = await supabase
         .from('chat_statuses')
-        .select('*, chats(*)')
+        .select('chat_id, status, chats(name)')
         .in('status', ['completed', 'archived']);
 
     if (error) {


### PR DESCRIPTION
This commit addresses a 500 Internal Server Error that was occurring on the `/api/admin/chats/pending` endpoint. It also hardens the frontend code to prevent crashes when API errors occur.

The backend fix involves making the `select()` statements in the three admin list endpoints in `server.js` more specific. Instead of `select('*, chats(*)')`, they now use `select('chat_id, status, chats(name)')`. This is a more secure and efficient way to fetch the data and is less likely to trigger an error in the database query engine if there are orphaned records.

The frontend fix involves refactoring the `loadAdminPanel` function in `script.js`. The new implementation checks that each `fetch` response has an `ok` status before attempting to call `.json()` on it. This prevents the `TypeError` that was being caused by trying to parse an error response as a JSON array.