### PR TITLE
feat: Display inactive chats in the selection list

### DIFF
--- a/backend/public/script.js
+++ b/backend/public/script.js
@@ -560,31 +560,31 @@ ${brokenCode}
             const response = await fetchWithAuth(`/api/chats?department_id=${deptId}`);
             const allChats = await response.json();
 
-            // Filter out completed and archived chats for the department view
-            const activeChats = allChats.filter(chat => {
-                const status = chat.chat_statuses?.status || 'draft';
-                return status !== 'completed' && status !== 'archived';
-            });
-
-            if (activeChats.length === 0) {
-                chatSelectionContainer.innerHTML = '<p class="placeholder-text">Для этого департамента нет активных чатов.</p>';
+            if (allChats.length === 0) {
+                chatSelectionContainer.innerHTML = '<p class="placeholder-text">Для этого департамента нет чатов.</p>';
                 return;
             }
 
-            chatSelectionContainer.innerHTML = activeChats.map(chat => {
+            chatSelectionContainer.innerHTML = allChats.map(chat => {
                 const status = chat.chat_statuses?.status || 'draft';
+                const isInactive = status === 'completed' || status === 'archived';
                 return `
-                <div class="chat-card" data-chat-id="${chat.id}" data-chat-name="${chat.name}">
-                    <span class="chat-icon">💬</span>
-                    <span class="chat-name">${chat.name}</span>
-                    <div class="chat-status">${getStatusIndicator(status)}</div>
-                </div>
-            `}).join('');
+            <div class="chat-card ${isInactive ? 'inactive' : ''}" data-chat-id="${chat.id}" data-chat-name="${chat.name}">
+                <span class="chat-icon">💬</span>
+                <span class="chat-name">${chat.name}</span>
+                <div class="chat-status">${getStatusIndicator(status)}</div>
+            </div>
+        `}).join('');
 
             document.querySelectorAll('.chat-card').forEach(card => {
                 card.addEventListener('click', () => {
+                    if (card.classList.contains('inactive')) {
+                        chatError.textContent = 'Этот чат завершен или архивирован.';
+                        return;
+                    }
                     document.querySelectorAll('.chat-card').forEach(c => c.classList.remove('selected'));
                     card.classList.add('selected');
+                    chatError.textContent = '';
                 });
             });
         } catch (error) {

--- a/backend/public/style.css
+++ b/backend/public/style.css
@@ -733,6 +733,18 @@ button.button-secondary:hover {
     background-color: #f8f9fa;
     border-radius: var(--border-radius);
 }
+
+.chat-card.inactive {
+    opacity: 0.6;
+    background-color: #f8f9fa;
+    cursor: not-allowed;
+}
+
+.chat-card.inactive:hover {
+    transform: none;
+    box-shadow: none;
+    border-color: var(--border-color);
+}
 .legend h4 {
     margin-top: 0;
     margin-bottom: 10px;


### PR DESCRIPTION
Modified the chat loading functionality to show all chats, including those marked as 'completed' or 'archived'.

- Updated `loadChats` in `script.js` to render all chats returned from the API.
- Added an 'inactive' class to completed or archived chats.
- Prevented selection of inactive chats and display an error message on click.
- Added CSS styles in `style.css` to visually distinguish inactive chats (faded, non-interactive).

This addresses the issue where departments with only inactive chats would incorrectly show a "no active chats" message.