### PR TITLE
feat: Secure the /api/generate endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,7 @@ app.put('/api/chats/:id/status', isAuthenticated, checkStatusChangePermission, a
     res.json(data);
 });
 
-app.post('/api/generate', async (req, res) => {
+app.post('/api/generate', isAuthenticated, async (req, res) => {
   const { prompt } = req.body;
   const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
   const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GOOGLE_API_KEY}`;

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -160,3 +160,12 @@ describe('GET /api/admin/chats/pending', () => {
         expect(orMock).toHaveBeenCalledWith('status.eq.draft,status.eq.needs_revision', { referencedTable: 'chat_statuses' });
     });
 });
+
+describe('/api/generate endpoint', () => {
+    it('should return 401 Unauthorized if user is not authenticated', async () => {
+        const response = await request(app)
+            .post('/api/generate')
+            .send({ prompt: 'test prompt' });
+        expect(response.status).toBe(401);
+    });
+});


### PR DESCRIPTION
Adds the `isAuthenticated` middleware to the `/api/generate` endpoint to prevent unauthenticated access. This resolves a security vulnerability that could have led to unauthorized use of the Google Gemini API.

A new test case has been added to verify that unauthenticated requests to this endpoint are correctly rejected with a 401 status.