### PR TITLE
Fix: Correct dotenv path in backend/server.js

### DIFF
--- a/backend/node_output.log
+++ b/backend/node_output.log
@@ -1,0 +1,1 @@
+Server is running on port 3000

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,6 @@
 
-require('dotenv').config({ path: __dirname + '/.env' });
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
 
 const express = require('express');
 const fetch = require('node-fetch');
@@ -8,7 +9,6 @@ const { createClient } = require('@supabase/supabase-js');
 const bcrypt = require('bcryptjs');
 const session = require('express-session');
 const FileStore = require('session-file-store')(session);
-const path = require('path');
 
 const app = express();
 


### PR DESCRIPTION
The server was crashing on startup because it could not find the .env file in the backend directory. This change corrects the path to look for the .env file in the root directory of the project, allowing the server to load the necessary environment variables and start correctly.