### PR TITLE
fix: Adapt environment variable loading for production

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,7 @@
 
-require('dotenv').config();
+if (process.env.NODE_ENV !== 'production') {
+  require('dotenv').config();
+}
 
 const path = require('path');
 const express = require('express');
@@ -19,7 +21,7 @@ const supabaseKey = process.env.SUPABASE_SERVICE_KEY;
 
 // Validate environment variables
 if (!supabaseUrl || !supabaseKey || !process.env.SESSION_SECRET) {
-  console.error("Error: SUPABASE_URL, SUPABASE_SERVICE_KEY, and SESSION_SECRET must be set in the .env file.");
+  console.error("Error: SUPABASE_URL, SUPABASE_SERVICE_KEY, and SESSION_SECRET must be set as environment variables.");
   process.exit(1);
 }
 


### PR DESCRIPTION
This commit modifies the server to conditionally load the `dotenv` library only when `NODE_ENV` is not set to `'production'`.

This change addresses a deployment issue where the application would fail to start because it was incorrectly trying to find a `.env` file in a production environment where variables are injected directly by the server.

The server now correctly prioritizes injected environment variables in production while still supporting the `.env` file for local development and testing. The startup error message has also been updated to be more generic.