### PR TITLE
Fix: Use database-backed sessions for production

### DIFF
--- a/DEPLOYMENT_INSTRUCTIONS.md
+++ b/DEPLOYMENT_INSTRUCTIONS.md
@@ -12,10 +12,12 @@ In your service's dashboard on **Render.com**, go to the **"Environment"** secti
 
 Please verify that you have added variables with these **exact** names. A small typo (like a missing underscore) will cause the error.
 
-*   `SUPABASE_URL`
-*   `SUPABASE_SERVICE_KEY`
-*   `SESSION_SECRET`
-*   `GOOGLE_API_KEY`
+*   `FRONTEND_URL`: The public URL of your deployed application (e.g., `https://your-app-name.onrender.com`). This is crucial for security (CORS).
+*   `SUPABASE_URL`: The URL of your Supabase project.
+*   `SUPABASE_SERVICE_KEY`: Your secret Supabase service role key.
+*   `GOOGLE_API_KEY`: Your API key for Google Gemini.
+*   `SESSION_SECRET`: A long, random string for securing sessions. You can generate one by running the following command in your terminal: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
+*   `DATABASE_URL`: The connection string for your Supabase database. Find this in your Supabase dashboard under `Settings` > `Database` > `Connection string`. This is required for persistent session storage.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,3 @@
-
 # The URL of the frontend application that will be making requests to this server.
 FRONTEND_URL=http://127.0.0.1:5500
 
@@ -15,8 +14,9 @@ SESSION_SECRET=your-super-secret-session-string
 # Supabase Project URL
 SUPABASE_URL=YOUR_SUPABASE_URL
 
-# Supabase Anon Key (public)
-SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
+# Supabase Service Key (secret)
+SUPABASE_SERVICE_KEY=YOUR_SUPABASE_SERVICE_KEY
 
-# A secret key for signing the session ID cookie. Change this for production.
-SESSION_SECRET=a-secure-secret-for-development
+# Supabase Database Connection String (for session storage)
+# Find this in your Supabase dashboard: Settings > Database > Connection string
+DATABASE_URL=YOUR_DATABASE_CONNECTION_STRING

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
     "bcryptjs": "^3.0.2",
+    "connect-pg-simple": "^9.0.1",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
@@ -25,7 +26,7 @@
     "jest": "^30.1.3",
     "jest-when": "^3.7.0",
     "node-fetch": "2.7.0",
-    "session-file-store": "^1.5.0",
+    "pg": "^8.11.3",
     "supertest": "^7.1.4"
   }
 }


### PR DESCRIPTION
Replaces the ephemeral `session-file-store` with `connect-pg-simple` to provide a persistent session store using the application's PostgreSQL database. This is essential for a stateless deployment environment like Render and resolves the persistent 401 Unauthorized errors.

- Adds `connect-pg-simple` and `pg` dependencies.
- Configures `server.js` to use `PGStore` for sessions.
- Adds `app.set('trust proxy', 1)` to correctly handle secure cookies.
- Updates CORS policy to use a specific `FRONTEND_URL`.
- Adds `DATABASE_URL` and `FRONTEND_URL` to documentation and .env.example.