### PR TITLE
feat: Implement robust production session handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -42,7 +42,9 @@ const pgPool = new (require('pg').Pool)({
     connectionString: process.env.DATABASE_URL,
     ssl: {
         rejectUnauthorized: false
-    }
+    },
+    // Force IPv4, as Render's environment may not support IPv6
+    family: 4,
 });
 
 app.use(session({


### PR DESCRIPTION
This commit resolves a series of deployment and runtime errors encountered on the Render platform by implementing a production-ready architecture.

The primary change is the replacement of the ephemeral `session-file-store` with `connect-pg-simple`, moving session storage to the persistent PostgreSQL database. This fixes the root cause of 401 Unauthorized errors that occurred due to sessions being lost on server restarts.

Additionally, this commit includes critical environment-specific fixes:
- Sets `trust proxy` to ensure secure cookies function correctly behind Render's reverse proxy.
- Forces the `pg` connection to use IPv4 to resolve `ENETUNREACH` network errors.
- Replaces the Supabase connection pooler URL with the direct database connection string to avoid IP allowlist issues.
- Hardens the CORS policy by requiring a `FRONTEND_URL`.
- Updates all documentation and environment examples to reflect these new requirements.