### PR TITLE
fix(auth): Reorder Express middleware to resolve auth issue

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -27,17 +27,9 @@ if (!supabaseUrl || !supabaseKey || !process.env.SESSION_SECRET) {
 
 const supabase = createClient(supabaseUrl, supabaseKey);
 
-// CORS configuration must allow credentials
-// The `origin` is set to `true` to reflect the request's origin (e.g., the URL in the browser).
-// This is a flexible setting for deployments where the frontend URL isn't fixed.
-app.use(cors({
-    origin: true,
-    credentials: true
-}));
-
 app.use(express.json()); 
 
-// Session middleware
+// Session middleware must be configured before CORS to ensure cookies are handled correctly.
 app.use(session({
     store: new FileStore({
         path: path.join(__dirname, 'sessions')
@@ -52,6 +44,13 @@ app.use(session({
         sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax', // Use 'none' for cross-site cookies in prod
         maxAge: 24 * 60 * 60 * 1000 // 24 hours
     }
+}));
+
+// CORS configuration must allow credentials.
+// The `origin` is set to `true` to reflect the request's origin.
+app.use(cors({
+    origin: true,
+    credentials: true
 }));
 
 app.use(express.static('public'));

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -1,3 +1,8 @@
+// Set dummy environment variables before importing the server
+process.env.SUPABASE_URL = 'http://dummy.url';
+process.env.SUPABASE_SERVICE_KEY = 'dummy-key';
+process.env.SESSION_SECRET = 'dummy-secret';
+
 const request = require('supertest');
 const { when } = require('jest-when');
 const bcrypt = require('bcryptjs');


### PR DESCRIPTION
The user was unable to access the admin panel due to an "Unauthorized" error, even with correct credentials. This was caused by the Express middleware being in the wrong order in `backend/server.js`.

The `cors()` middleware was being initialized before the `session()` middleware. This prevented the session from being correctly established before CORS policies were applied, leading to the session cookie not being sent or recognized on subsequent requests.

This change reorders the middleware to the correct sequence:
1. `express.json()`
2. `session()`
3. `cors()`

This ensures the session is available for all authenticated routes.

Additionally, the test suite in `backend/server.test.js` was failing because it required environment variables to be set. Dummy variables have been added to the test file to make the test suite self-contained and runnable in any environment.