### PR TITLE
Fix: Correct SUPABASE_SERVICE_KEY in .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,8 +15,10 @@ SESSION_SECRET=your-super-secret-session-string
 # Supabase Project URL
 SUPABASE_URL=YOUR_SUPABASE_URL
 
-# Supabase Anon Key (public)
-SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
+# Supabase Service Role Key (secret)
+# IMPORTANT: This must be the "service_role" key, not the "anon" key.
+# The service_role key is required for server-side admin operations.
+SUPABASE_SERVICE_KEY=YOUR_SUPABASE_SERVICE_KEY
 
 # A secret key for signing the session ID cookie. Change this for production.
 SESSION_SECRET=a-secure-secret-for-development


### PR DESCRIPTION
The `server.js` file requires the `SUPABASE_SERVICE_KEY` environment variable to be set for server-side operations with Supabase. However, the `.env.example` file incorrectly specified `SUPABASE_ANON_KEY`, which is a public key for client-side use.

This change corrects the variable name in the `.env.example` file to `SUPABASE_SERVICE_KEY` and adds a comment to clarify that the secret service role key should be used. This will prevent confusion for developers setting up the project and resolve potential authentication errors.