### PR TITLE
fix: Update session cookie settings to fix auth issue

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -50,7 +50,7 @@ app.use(session({
     cookie: {
         httpOnly: true, // Prevent client-side JS from accessing the cookie
         secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax', // Use 'none' for cross-site cookies in prod
+        sameSite: process.env.NODE_ENV === 'production' ? 'none' : undefined, // Omit for non-production to allow cross-site dev
         maxAge: 24 * 60 * 60 * 1000 // 24 hours
     }
 }));


### PR DESCRIPTION
- Changed the `sameSite` cookie attribute to `undefined` for non-production environments.
- This is to prevent browsers from blocking the session cookie during cross-origin requests in a local development environment (HTTP).