### PR TITLE
fix: Add 'trust proxy' setting for secure cookies

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -14,6 +14,7 @@ const session = require('express-session');
 const FileStore = require('session-file-store')(session);
 
 const app = express();
+app.set('trust proxy', 1); // Trust the first proxy
 const PORT = process.env.PORT || 3000;
 
 let pool;


### PR DESCRIPTION
- Added `app.set('trust proxy', 1)` to the Express app configuration.
- This ensures that `secure: true` session cookies are handled correctly when the application is running behind a reverse proxy, such as on Render.
- This should resolve the final 'Unauthorized' error by allowing the browser to properly save and send the session cookie over HTTPS.