### PR TITLE
Fix: Prevent server crash on DNS lookup failure

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -7,8 +7,6 @@ const express = require('express');
 const fetch = require('node-fetch');
 const cors = require('cors');
 const { Pool } = require('pg');
-const { parse } = require('pg-connection-string');
-const dns = require('dns').promises;
 const bcrypt = require('bcryptjs');
 const session = require('express-session');
 const FileStore = require('session-file-store')(session);
@@ -423,16 +421,8 @@ const startServer = async () => {
         }
 
         console.log('Initializing database connection...');
-        const dbUrl = process.env.DATABASE_URL;
-        const config = parse(dbUrl);
-
-        console.log(`Looking up IPv4 address for host: ${config.host}`);
-        const { address } = await dns.lookup(config.host, { family: 4 });
-        console.log(`Resolved ${config.host} to ${address}`);
-
         pool = new Pool({
-            ...config,
-            host: address,
+            connectionString: process.env.DATABASE_URL,
             ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
         });
 

--- a/backend/server_output.log
+++ b/backend/server_output.log
@@ -1,2 +1,8 @@
-[dotenv@17.2.2] injecting env (0) from .env -- tip: 🛠️  run anywhere with `dotenvx run -- yourcommand`
+[dotenv@17.2.2] injecting env (5) from .env -- tip: 📡 version env with Radar: https://dotenvx.com/radar
+Initializing database connection...
+Database connection successful.
 Server is running on port 3000
+Admin user not found, creating it...
+Admin user created.
+Regular user not found, creating it...
+Regular user created.


### PR DESCRIPTION
The server was performing a manual DNS lookup for the database host before creating the connection pool. If this lookup failed (e.g., due to an invalid hostname or a transient network issue), the server would crash with an unhandled `ENOTFOUND` error.

This commit removes the explicit `dns.lookup` call and simplifies the `pg.Pool` instantiation. The pool is now created by passing the `DATABASE_URL` directly to the `connectionString` option, letting the `pg` library manage the connection and DNS resolution internally.

This makes the server more resilient to DNS issues and aligns the connection logic with standard practices for the `node-postgres` library.