### PR TITLE
fix: Resolve WebSocket and Rev.ai SDK errors

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "node-fetch": "2.7.0",
     "pg": "^8.11.3",
     "pg-connection-string": "^2.6.2",
-    "rev_ai": "^0.5.1",
+    "revai-node-sdk": "^3.0.0",
     "session-file-store": "^1.5.0",
     "supertest": "^7.1.4",
     "ws": "^8.18.3"

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,7 +13,7 @@ const bcrypt = require('bcryptjs');
 const session = require('express-session');
 const FileStore = require('session-file-store')(session);
 const WebSocket = require('ws');
-const { RevAiStreamingClient, AudioEncoding } = require('rev_ai');
+const revai = require('revai-node-sdk');
 
 const app = express();
 app.set('trust proxy', 1); // Trust the first proxy
@@ -45,16 +45,14 @@ app.use(express.static('public'));
 const wss = new WebSocket.Server({ noServer: true });
 
 wss.on('connection', ws => {
-    const revaiClient = new RevAiStreamingClient({
-        accessToken: process.env.REV_AI_API_KEY,
-        config: {
-            contentType: "audio/x-raw",
-            layout: "interleaved",
-            rate: 44100,
-            format: "S16LE",
-            channels: 1,
-        },
-    });
+    const audioConfig = new revai.AudioConfig(
+        "audio/x-raw",
+        "interleaved",
+        44100,
+        "S16LE",
+        1
+    );
+    const revaiClient = new revai.RevAiStreamingClient({ token: process.env.REV_AI_API_KEY }, audioConfig);
 
     revaiClient.on('close', (code, reason) => console.log(`Rev.ai connection closed: ${code} - ${reason}`));
     revaiClient.on('httpResponse', code => console.log(`Rev.ai streaming HTTP response: ${code}`));


### PR DESCRIPTION
This commit addresses two critical issues that prevented the real-time transcription feature from working.

First, it resolves a "Mixed Content" error on the client-side. The application, when loaded over HTTPS, was attempting to connect to an insecure `ws://` WebSocket. This is now fixed by dynamically setting the protocol to `wss://` on secure pages. A cache-busting query parameter has also been added to `index.html` to ensure clients receive this fix.

Second, it resolves a `TypeError: RevAiStreamingClient is not a constructor` on the server-side. This was caused by an outdated `rev_ai` package. The dependency has been updated to the modern `revai-node-sdk`, and the server code has been refactored to use the new, correct API for initializing the streaming client.