### PR TITLE
fix: Use yarn instead of npm in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@
 cd backend
 
 # Установить зависимости
-npm install
+yarn install
 
 # Запустить приложение
-npm start
+yarn start


### PR DESCRIPTION
This commit corrects the startup script (`start.sh`) to use `yarn` commands (`yarn install`, `yarn start`) instead of `npm`.

The previous version of the script was using `npm`, which was not found in the final Docker container's runtime environment, causing a "npm: not found" error.

This change aligns the startup script with the project's dependency manager (Yarn), which should resolve the runtime error and allow the application to start correctly.