### PR TITLE
Fix transcription form issues

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -141,7 +141,7 @@
                     </div>
 
                     <div class="textarea-wrapper">
-                        <textarea id="transcription-output" rows="6" placeholder="Здесь появится текст после обработки аудио..."></textarea>
+                        <textarea id="transcription-output" rows="12" placeholder="Здесь появится текст после обработки аудио..."></textarea>
                     </div>
                     <div id="partial-transcript-display" class="partial-transcript"></div>
                 </div>

--- a/backend/public/script.js
+++ b/backend/public/script.js
@@ -1203,6 +1203,8 @@ ${brokenCode}
             if (response.ok) {
                 showNotification('Транскрибация успешно завершена.', 'success');
                 transcriptionOutput.value = data.transcript; // Put text in the new field
+                processDescriptionInput.value = data.transcript;
+                updateStepCounter();
                 // Keep audio controls available
                 processBtn.style.display = 'none'; // Hide process button after use
             } else {


### PR DESCRIPTION
This commit addresses several issues in the transcription form:

1.  The transcribed text from audio recording is now correctly placed into the main process description input field, which allows it to be saved.
2.  The textarea for the transcription output has been resized to be larger and more consistent with other form fields.

These changes fix the bug where transcription text was not being saved and improve the user experience of the form.