### PR TITLE
Rework transcription field logic

### DIFF
--- a/backend/public/script.js
+++ b/backend/public/script.js
@@ -674,7 +674,7 @@ ${brokenCode}
     }
 
     async function handleSaveVersion(button = saveVersionBtn) {
-        const process_text = processDescriptionInput.value;
+        const process_text = transcriptionOutput.value;
         if (!process_text.trim()) {
             showNotification("Нельзя сохранить пустую версию.", "error");
             return;
@@ -1047,7 +1047,7 @@ ${brokenCode}
     }
 
     async function handleSaveRawVersion(button = saveRawVersionBtn) {
-        const process_text = processDescriptionInput.value;
+        const process_text = transcriptionOutput.value;
         if (!process_text.trim()) {
             showNotification("Нельзя сохранить пустую версию.", "error");
             return;
@@ -1202,8 +1202,6 @@ ${brokenCode}
             if (response.ok) {
                 showNotification('Транскрибация успешно завершена.', 'success');
                 transcriptionOutput.value = data.transcript; // Put text in the new field
-                processDescriptionInput.value = data.transcript;
-                updateStepCounter();
                 // Keep audio controls available
                 processBtn.style.display = 'none'; // Hide process button after use
             } else {

--- a/backend/public/style.css
+++ b/backend/public/style.css
@@ -147,7 +147,8 @@ textarea#process-description, #user-prompt {
     transition: border-color 0.2s, box-shadow 0.2s;
 }
 
-textarea#process-description {
+textarea#process-description,
+textarea#transcription-output {
     min-height: 220px;
 }
 


### PR DESCRIPTION
This commit reworks the logic for the transcription field based on user feedback.

1.  The text field for transcription output is now the primary source for saving. The save functions now read from this field directly.
2.  The text field has been resized with CSS to be consistent with other fields on the page.
3.  The logic that copied the transcript to a second field has been removed to simplify the workflow.