### PR TITLE
Refactor transcription display and behavior

### DIFF
--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -127,7 +127,7 @@
         <main class="main-content">
             <div class="left-column">
                 <div class="input-block">
-                    <label for="transcription-output">1. Опишите или запишите ваш бизнес-процесс</label>
+                    <label for="transcription-display">1. Опишите или запишите ваш бизнес-процесс</label>
 
                     <div class="audio-recorder-block">
                         <button id="start-record-btn" class="button-secondary">🎙️ Начать запись</button>
@@ -140,9 +140,7 @@
                         <audio id="audio-playback" controls class="audio-playback"></audio>
                     </div>
 
-                    <div class="textarea-wrapper">
-                        <textarea id="transcription-output" rows="12" placeholder="Здесь появится текст после обработки аудио..."></textarea>
-                    </div>
+                    <div id="transcription-display" class="transcription-display-area"></div>
                     <div id="partial-transcript-display" class="partial-transcript"></div>
                 </div>
 

--- a/backend/public/script.js
+++ b/backend/public/script.js
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const audioPlayback = document.getElementById('audio-playback');
     const recordingIndicator = document.getElementById('recording-indicator');
     const recordingTimer = document.getElementById('recording-timer');
-    const transcriptionOutput = document.getElementById('transcription-output');
+    const transcriptionDisplay = document.getElementById('transcription-display');
     const transcriptionTimer = document.getElementById('transcription-timer');
     const partialTranscriptDisplay = document.getElementById('partial-transcript-display');
     const versionHistoryContainer = document.getElementById('version-history-container');
@@ -864,6 +864,9 @@ ${brokenCode}
             showNotification('Транскрибация успешно сохранена!', 'success');
             updateTranscriptionModalUI(data);
             if (isFinalizing) {
+                transcriptionDisplay.textContent = text;
+                processDescriptionInput.value = text;
+                updateStepCounter();
                 closeTranscriptionModal();
             }
         } catch (error) {
@@ -1088,7 +1091,7 @@ ${brokenCode}
         audioChunks = [];
         rerecordCount = 0;
         processDescriptionInput.readOnly = false;
-        transcriptionOutput.value = ''; // Clear the new textarea as well
+        transcriptionDisplay.textContent = ''; // Clear the display area
 
         startRecordBtn.style.display = 'block';
         stopRecordBtn.style.display = 'none';
@@ -1201,7 +1204,7 @@ ${brokenCode}
 
             if (response.ok) {
                 showNotification('Транскрибация успешно завершена.', 'success');
-                transcriptionOutput.value = data.transcript; // Put text in the new field
+                transcriptionDisplay.textContent = data.transcript;
                 processDescriptionInput.value = data.transcript;
                 updateStepCounter();
                 // Keep audio controls available

--- a/backend/public/style.css
+++ b/backend/public/style.css
@@ -157,6 +157,19 @@ textarea#process-description:focus, #user-prompt:focus {
     box-shadow: 0 0 0 3px rgba(59, 113, 246, 0.2);
 }
 
+.transcription-display-area {
+    width: 100%;
+    min-height: 150px; /* Give it some default height */
+    padding: 15px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: var(--light-bg-color); /* A light grey to indicate it's not editable */
+    font-size: 1em;
+    white-space: pre-wrap; /* To respect line breaks from the transcript */
+    word-wrap: break-word; /* To break long words */
+    margin-bottom: 20px;
+}
+
 .step-counter {
     position: absolute;
     bottom: 12px;


### PR DESCRIPTION
This commit addresses the user's request to change the behavior of the transcription display fields.

- Replaced the 'transcription-output' textarea with a non-editable 'div' to permanently display the finalized transcript.
- Updated the associated CSS to style the new div as a display area.
- Modified the JavaScript logic to ensure that when a transcript is finalized in the modal:
  - The text is correctly displayed in the new non-editable div.
  - The text is also copied to the 'process-description' textarea for further editing.
- Updated the reset logic to clear the new display div when a re-record is initiated.

This change simplifies the UI logic by removing the need to toggle the readOnly property and directly implements the desired non-editable state for the final transcript.