### PR TITLE
Refactor(transcription): Make display non-editable and fix persistence

### DIFF
--- a/backend/public/script.js
+++ b/backend/public/script.js
@@ -613,12 +613,21 @@ ${brokenCode}
             renderVersions(chatVersions);
             renderComments(comments);
 
+            // Handle loading of finalized transcript into its display area (Field 1)
             if (transcriptionData && transcriptionData.status === 'finalized') {
-                processDescriptionInput.value = transcriptionData.final_text;
-                // Maybe show a button to open the modal in read-only mode
-            } else if (chatVersions.length > 0) {
+                transcriptionDisplay.textContent = transcriptionData.final_text;
+            }
+
+            // Handle loading for the editable process description (Field 2)
+            if (chatVersions.length > 0) {
+                // If saved versions exist, load the latest one into Field 2
                 await displayVersion(chatVersions[0]);
+            } else if (transcriptionData && transcriptionData.status === 'finalized') {
+                // Otherwise, if no versions exist but a transcript does, use it as the initial value for Field 2
+                processDescriptionInput.value = transcriptionData.final_text;
+                updateStepCounter();
             } else {
+                // Otherwise, ensure Field 2 is empty
                 await displayVersion(null);
             }
 


### PR DESCRIPTION
This commit addresses the user's request to change the behavior of the transcription display fields and fixes a data persistence bug.

- Replaced the 'transcription-output' textarea with a non-editable 'div' (`transcription-display`) to permanently display the finalized transcript.
- Updated CSS to style the new div as a display area.
- Modified the JavaScript logic to ensure that when a transcript is finalized in the modal:
  - The text is correctly displayed in the new non-editable div.
  - The text is also copied to the 'process-description' textarea for further editing.
- Fixed a bug where the finalized transcript was not being reloaded into the new display div when the user re-entered the chat. The `loadChatData` function is now updated to handle this.
- Updated all relevant JS functions (`handleProcessAudio`, `resetAudioState`) to use the new div.
- Refactored `loadChatData` to correctly and independently restore the state for the finalized transcript display and the editable process description, ensuring user edits are not overwritten on page load.